### PR TITLE
measure_thermal_behavior: temp_data restructure, tweaks

### DIFF
--- a/measure_thermal_behavior.py
+++ b/measure_thermal_behavior.py
@@ -238,12 +238,12 @@ def query_temp_sensors():
         frame_current = -180.
 
     extra_temps = {}
-    if EXTRA_SENSORS != {}:
-        try:
-            for sensor in EXTRA_SENSORS:
+    if EXTRA_SENSORS:
+        for sensor in EXTRA_SENSORS:
+            try:
                 extra_temps[sensor] = resp[EXTRA_SENSORS[sensor]]['temperature']
-        except KeyError:
-            extra_temps[sensor] = -180.
+            except KeyError:
+                extra_temps[sensor] = -180.
 
     bed_current = resp['heater_bed']['temperature']
     bed_target = resp['heater_bed']['target']

--- a/measure_thermal_behavior.py
+++ b/measure_thermal_behavior.py
@@ -223,7 +223,7 @@ def query_temp_sensors():
         extra_t_str += '&%s' % CHAMBER_SENSOR
     if FRAME_SENSOR:
         extra_t_str += '&%s' % FRAME_SENSOR
-    if EXTRA_SENSORS != {}:
+    if EXTRA_SENSORS:
         extra_t_str += '&%s' % '&'.join(EXTRA_SENSORS.values())
 
     base_t_str = 'extruder&heater_bed'
@@ -275,7 +275,6 @@ def query_mcu_z_pos():
 
 
 def wait_for_bedtemp():
-    global start_time
     at_temp = False
     print('Heating started')
     while(1):
@@ -283,7 +282,6 @@ def wait_for_bedtemp():
         if temps['bed_temp'] >= BED_TEMPERATURE-0.5:
             at_temp = True
             break
-    start_time = datetime.now()
     print('\nBed temp reached')
 
 
@@ -362,6 +360,7 @@ def main():
     set_hetemp(HE_TEMPERATURE)
 
     wait_for_bedtemp()
+    start_time = datetime.now()
 
     # Take cold mesh
     take_bed_mesh()
@@ -374,9 +373,9 @@ def main():
                  'mesh': cold_mesh}
 
     print('Cold mesh taken, waiting for %s minutes' % (HOT_DURATION * 60))
-    # wait for heat soak
 
     temps = {}
+    # wait for heat soak
     while(1):
         now = datetime.now()
         if (now - start_time) >= timedelta(hours=HOT_DURATION):
@@ -399,7 +398,6 @@ def main():
     print('Hot measurements complete!')
     set_bedtemp()
 
-    start_time = datetime.now()
     while(1):
         now = datetime.now()
         if (now - start_time) >= timedelta(hours=HOT_DURATION+COOL_DURATION):


### PR DESCRIPTION
Reformat `temp_data` data structure as e.g:
```json
    "temp_data": {
        "2021/08/02-18:09:24": {
            "ambient_t": 25.045069874183582,
            "bed_target": 105.0,
            "bed_temp": 70.55504880410373,
            "chamber_temp": 28.64916624748446,
            "frame_temp": 25.01276217159301,
            "he_target": 100.0,
            "he_temp": 100.10888741760135,
            "mcu_z": -5587,
            "sample_index": 0
        },
        "2021/08/02-18:09:28": {
            "ambient_t": 25.01276217159301,
            "bed_target": 105.0,
            "bed_temp": 70.96215755085439,
            "chamber_temp": 28.462018360494767,
            "frame_temp": 24.899409750362793,
            "he_target": 100.0,
            "he_temp": 99.61074527343162,
            "mcu_z": -5586,
            "sample_index": 0
        }
   }
```

Move start_time to after bed is heated, remove extra start_time from before cold measurements.